### PR TITLE
Increase z-index to show hints when sticky titles is enabled

### DIFF
--- a/plugins/cmplus/$__plugins_tiddlywiki_codemirror_addon_hint_show-hint.css
+++ b/plugins/cmplus/$__plugins_tiddlywiki_codemirror_addon_hint_show-hint.css
@@ -1,6 +1,6 @@
 .CodeMirror-hints {
   position: absolute;
-  z-index: 10;
+  z-index: 200;
   overflow: hidden;
   list-style: none;
 


### PR DESCRIPTION
The default themes (Vanilla and Snow White) set a z-index of 198 (for the first tiddler) when "sticky titles" is enabled, which covers the autocomplete hint. By setting z-index to 200, the hint will be visible in these cases.